### PR TITLE
Solved linking issue with pcl

### DIFF
--- a/include/pclomp/ndt_omp.h
+++ b/include/pclomp/ndt_omp.h
@@ -42,6 +42,7 @@
 #define PCL_REGISTRATION_NDT_OMP_H_
 
 #include <pcl/registration/registration.h>
+#include <pcl/search/impl/search.hpp>
 #include "voxel_grid_covariance_omp.h"
 
 #include <unsupported/Eigen/NonLinearOptimization>


### PR DESCRIPTION
This PR solves a linking problem with pcl::search::Search::getName method:

```bash
(.data.rel.ro._ZTVN3pcl6search6SearchINS_8PointXYZEEE[_ZTVN3pcl6search6SearchINS_8PointXYZEEE]+0x20): undefined reference to `pcl::search::Search<pcl::PointXYZ>::getName[abi:cxx11]() const'
CMakeFiles/align.dir/apps/align.cpp.o:(.data.rel.ro._ZTVN3pcl6search6KdTreeINS_8PointXYZENS_11KdTreeFLANNIS2_N5flann9L2_SimpleIfEEEEEE[_ZTVN3pcl6search6KdTreeINS_8PointXYZENS_11KdTreeFLANNIS2_N5flann9L2_SimpleIfEEEEEE]+0x20): undefined reference to `pcl::search::Search<pcl::PointXYZ>::getName[abi:cxx11]() const'
/home/mbosch/workspaces/ndt_omp/devel/.private/ndt_omp/lib/libndt_omp.so: undefined reference to `pcl::search::Search<pcl::PointXYZI>::getName[abi:cxx11]() const'
collect2: error: ld returned 1 exit status
make[2]: *** [/home/mbosch/workspaces/ndt_omp/devel/.private/ndt_omp/lib/ndt_omp/align] Error 1
make[1]: *** [CMakeFiles/align.dir/all] Error 2
make: *** [all] Error 2
```
Current setup:
ROS Kinetic (updated at 2019-08-19)
Ubuntu 16.04 (updated at 2019-08-19)
PCL 1.7 (libpcl1.7, 1.7.2-14build1)

Solution proposed comes from:
https://github.com/PointCloudLibrary/pcl/issues/2406#issuecomment-428101801