### PR TITLE
Change boost::shared_ptr to std::shared_ptr

### DIFF
--- a/include/pclomp/gicp_omp.h
+++ b/include/pclomp/gicp_omp.h
@@ -91,14 +91,14 @@ namespace pclomp
       using PointIndicesConstPtr = pcl::PointIndices::ConstPtr;
 
       using MatricesVector = std::vector<Eigen::Matrix3d, Eigen::aligned_allocator<Eigen::Matrix3d> >;
-      using MatricesVectorPtr = boost::shared_ptr<MatricesVector>;
-      using MatricesVectorConstPtr = boost::shared_ptr<const MatricesVector>;
+      using MatricesVectorPtr = pcl::shared_ptr<MatricesVector>;
+      using MatricesVectorConstPtr = pcl::shared_ptr<const MatricesVector>;
 
       using InputKdTree = typename pcl::Registration<PointSource, PointTarget>::KdTree;
       using InputKdTreePtr = typename pcl::Registration<PointSource, PointTarget>::KdTreePtr;
 
-      using Ptr = boost::shared_ptr<GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
-      using ConstPtr = boost::shared_ptr<const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
+      using Ptr = pcl::shared_ptr<GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
+      using ConstPtr = pcl::shared_ptr<const GeneralizedIterativeClosestPoint<PointSource, PointTarget> >;
 
 
       using Vector6d = Eigen::Matrix<double, 6, 1>;

--- a/include/pclomp/ndt_omp.h
+++ b/include/pclomp/ndt_omp.h
@@ -95,8 +95,8 @@ namespace pclomp
 
 	public:
 
-		typedef boost::shared_ptr< NormalDistributionsTransform<PointSource, PointTarget> > Ptr;
-		typedef boost::shared_ptr< const NormalDistributionsTransform<PointSource, PointTarget> > ConstPtr;
+		typedef pcl::shared_ptr< NormalDistributionsTransform<PointSource, PointTarget> > Ptr;
+		typedef pcl::shared_ptr< const NormalDistributionsTransform<PointSource, PointTarget> > ConstPtr;
 
 
 		/** \brief Constructor.

--- a/include/pclomp/voxel_grid_covariance_omp.h
+++ b/include/pclomp/voxel_grid_covariance_omp.h
@@ -84,8 +84,8 @@ namespace pclomp
 
     public:
 
-      typedef boost::shared_ptr< pcl::VoxelGrid<PointT> > Ptr;
-      typedef boost::shared_ptr< const pcl::VoxelGrid<PointT> > ConstPtr;
+      typedef pcl::shared_ptr< pcl::VoxelGrid<PointT> > Ptr;
+      typedef pcl::shared_ptr< const pcl::VoxelGrid<PointT> > ConstPtr;
 
       /** \brief Simple structure to hold a centroid, covarince and the number of points in a leaf.
         * Inverse covariance, eigen vectors and engen values are precomputed. */


### PR DESCRIPTION
Starting with PCL 1.11, PCL uses `std::shared_ptr` and `std::weak_ptr` instead of the boost smart pointers. The change leverages type aliases included with the 1.10.0 release