### PR TITLE
exchange header order and replace pcl_isfinite with std::isfinite

### DIFF
--- a/include/pclomp/voxel_grid_covariance_omp.h
+++ b/include/pclomp/voxel_grid_covariance_omp.h
@@ -38,11 +38,11 @@
 #ifndef PCL_VOXEL_GRID_COVARIANCE_OMP_H_
 #define PCL_VOXEL_GRID_COVARIANCE_OMP_H_
 
+#include <pcl/pcl_macros.h>
 #include <pcl/filters/boost.h>
 #include <pcl/filters/voxel_grid.h>
 #include <map>
 #include <unordered_map>
-#include <pcl/pcl_macros.h>
 #include <pcl/point_types.h>
 #include <pcl/kdtree/kdtree_flann.h>
 

--- a/include/pclomp/voxel_grid_covariance_omp_impl.hpp
+++ b/include/pclomp/voxel_grid_covariance_omp_impl.hpp
@@ -133,9 +133,9 @@ pclomp::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
     {
       if (!input_->is_dense)
         // Check if the point is invalid
-        if (!pcl_isfinite (input_->points[cp].x) ||
-            !pcl_isfinite (input_->points[cp].y) ||
-            !pcl_isfinite (input_->points[cp].z))
+        if (!std::isfinite (input_->points[cp].x) ||
+            !std::isfinite (input_->points[cp].y) ||
+            !std::isfinite (input_->points[cp].z))
           continue;
 
       // Get the distance value
@@ -210,9 +210,9 @@ pclomp::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
     {
       if (!input_->is_dense)
         // Check if the point is invalid
-        if (!pcl_isfinite (input_->points[cp].x) ||
-            !pcl_isfinite (input_->points[cp].y) ||
-            !pcl_isfinite (input_->points[cp].z))
+        if (!std::isfinite (input_->points[cp].x) ||
+            !std::isfinite (input_->points[cp].y) ||
+            !std::isfinite (input_->points[cp].z))
           continue;
 
       int ijk0 = static_cast<int> (floor (input_->points[cp].x * inverse_leaf_size_[0]) - static_cast<float> (min_b_[0]));


### PR DESCRIPTION
This PR do these things:
1. <pcl/pcl_macros.h> should be included before <pcl/filters/boost.h>, or some errors may occur
> pcl/filters/boost.h:46:22: error: expected constructor, destructor, or type conversion before ‘(’ token PCL_DEPRECATED_HEADER(1, 15, "Please include the needed boost headers directly.")
2. replace pcl_isfinite with std::isfinite, solve  #8 

Current setup:
    Ubuntu 18.04
    PCL: 1.11