### PR TITLE
fix deprecated pcl::getFieldIndex

### DIFF
--- a/include/pclomp/voxel_grid_covariance_omp_impl.hpp
+++ b/include/pclomp/voxel_grid_covariance_omp_impl.hpp
@@ -110,9 +110,9 @@ pclomp::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
   // ---[ RGB special case
   std::vector<pcl::PCLPointField> fields;
   int rgba_index = -1;
-  rgba_index = pcl::getFieldIndex (*input_, "rgb", fields);
+  rgba_index = pcl::getFieldIndex<PointT> ("rgb", fields);
   if (rgba_index == -1)
-    rgba_index = pcl::getFieldIndex (*input_, "rgba", fields);
+    rgba_index = pcl::getFieldIndex<PointT> ("rgba", fields);
   if (rgba_index >= 0)
   {
     rgba_index = fields[rgba_index].offset;
@@ -124,7 +124,7 @@ pclomp::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
   {
     // Get the distance field index
     std::vector<pcl::PCLPointField> fields;
-    int distance_idx = pcl::getFieldIndex (*input_, filter_field_name_, fields);
+    int distance_idx = pcl::getFieldIndex<PointT> (filter_field_name_, fields);
     if (distance_idx == -1)
       PCL_WARN ("[pcl::%s::applyFilter] Invalid filter field name. Index is %d.\n", getClassName ().c_str (), distance_idx);
 


### PR DESCRIPTION
This PR fix:

> warning: ‘int pcl::getFieldIndex(const pcl::PointCloud<PointT>&, const string&, std::vector<pcl::PCLPointField>&) [with PointT = pcl::PointXYZ; std::string = std::__cxx11::basic_string<char>]’ is deprecated: use getFieldIndex<PointT> (field_name, fields) instead [-Wdeprecated-declarations]


My Environments
- Ubuntu 20.04
- pcl-1.10