### PR TITLE
fix warnings of sign-compare and ignored-qualifiers

### DIFF
--- a/include/pclomp/gicp_omp_impl.hpp
+++ b/include/pclomp/gicp_omp_impl.hpp
@@ -65,7 +65,7 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovar
   std::vector<std::vector<float>> nn_dist_sq_array(omp_get_max_threads());
 
   #pragma omp parallel for
-  for(int i=0; i<cloud->size(); i++) {
+  for(std::size_t i=0; i<cloud->size(); i++) {
     auto& nn_indecies = nn_indecies_array[omp_get_thread_num()];
     auto& nn_dist_sq = nn_dist_sq_array[omp_get_thread_num()];
 
@@ -284,7 +284,7 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::Optimization
   std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d>> R_array(omp_get_max_threads());
   std::vector<Eigen::Vector4d, Eigen::aligned_allocator<Eigen::Vector4d>> g_array(omp_get_max_threads());
 
-  for (int i = 0; i < R_array.size(); i++) {
+  for (std::size_t i = 0; i < R_array.size(); i++) {
 	  R_array[i].setZero();
 	  g_array[i].setZero();
   }
@@ -318,7 +318,7 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::Optimization
 
   g.setZero();
   Eigen::Matrix4d R = Eigen::Matrix4d::Zero();
-  for (int i = 0; i < R_array.size(); i++) {
+  for (std::size_t i = 0; i < R_array.size(); i++) {
 	  R += R_array[i];
 	  g.head<3>() += g_array[i].head<3>();
   }
@@ -338,7 +338,7 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::Optimization
   f = 0;
   g.setZero ();
   Eigen::Matrix3d R = Eigen::Matrix3d::Zero ();
-  const int m = static_cast<const int> (gicp_->tmp_idx_src_->size ());
+  const auto m = static_cast<int> (gicp_->tmp_idx_src_->size ());
   for (int i = 0; i < m; ++i)
   {
     // The last coordinate, p_src[3] is guaranteed to be set to 1.0 in registration.hpp
@@ -419,7 +419,7 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTrans
     const Eigen::Matrix3d R = transform_R.topLeftCorner<3,3> ();
 
     #pragma omp parallel for
-    for (int i = 0; i < N; i++)
+    for (std::size_t i = 0; i < N; i++)
     {
       auto& nn_indices = nn_indices_array[omp_get_thread_num()];
       auto& nn_dists = nn_dists_array[omp_get_thread_num()];
@@ -459,14 +459,14 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTrans
     source_indices.resize(cnt); target_indices.resize(cnt);
 
     std::vector<std::pair<int, int>> indices(source_indices.size());
-    for(int i = 0; i<source_indices.size(); i++) {
+    for(std::size_t i = 0; i<source_indices.size(); i++) {
       indices[i].first = source_indices[i];
       indices[i].second = target_indices[i];
     }
 
     std::sort(indices.begin(), indices.end(), [=](const std::pair<int, int>& lhs, const std::pair<int, int>& rhs) { return lhs.first < rhs.first; });
 
-    for(int i = 0; i < source_indices.size(); i++) {
+    for(std::size_t i = 0; i < source_indices.size(); i++) {
       source_indices[i] = indices[i].first;
       target_indices[i] = indices[i].second;
     }

--- a/include/pclomp/ndt_omp_impl.hpp
+++ b/include/pclomp/ndt_omp_impl.hpp
@@ -190,7 +190,7 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivativ
   std::vector<double> scores(input_->points.size());
   std::vector<Eigen::Matrix<double, 6, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 1>>> score_gradients(input_->points.size());
   std::vector<Eigen::Matrix<double, 6, 6>, Eigen::aligned_allocator<Eigen::Matrix<double, 6, 6>>> hessians(input_->points.size());
-  for (int i = 0; i < input_->points.size(); i++) {
+  for (std::size_t i = 0; i < input_->points.size(); i++) {
 		scores[i] = 0;
 		score_gradients[i].setZero();
 		hessians[i].setZero();
@@ -204,7 +204,7 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivativ
 
 	// Update gradient and hessian for each point, line 17 in Algorithm 2 [Magnusson 2009]
 #pragma omp parallel for num_threads(num_threads_) schedule(guided, 8)
-	for (int idx = 0; idx < input_->points.size(); idx++)
+	for (std::size_t idx = 0; idx < input_->points.size(); idx++)
 	{
 		int thread_n = omp_get_thread_num();
 
@@ -275,7 +275,7 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeDerivativ
 	}
 
   // Ensure that the result is invariant against the summing up order
-  for (int i = 0; i < input_->points.size(); i++) {
+  for (std::size_t i = 0; i < input_->points.size(); i++) {
 		score += scores[i];
 		score_gradient += score_gradients[i];
 		hessian += hessians[i];
@@ -936,7 +936,7 @@ double pclomp::NormalDistributionsTransform<PointSource, PointTarget>::calculate
 {
 	double score = 0;
 
-	for (int idx = 0; idx < trans_cloud.points.size(); idx++)
+	for (std::size_t idx = 0; idx < trans_cloud.points.size(); idx++)
 	{
 		PointSource x_trans_pt = trans_cloud.points[idx];
 


### PR DESCRIPTION
This PR fix these things
- `[-Werror=sign-compare]`
- `[-Werror=ignored-qualifiers]`

This occurs when I define the compile option as `-Wall -Wextra -Wpedantic -Werror`

My environment
Ubuntu 20:04
pcl-1.10