### PR TITLE
Change SIMD flags to support aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,15 @@
 cmake_minimum_required(VERSION 3.10)
 project(ndt_omp)
 
-# should use march=native ?
-add_definitions(-std=c++14 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
-set(CMAKE_CXX_FLAGS "-std=c++14 -msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
+add_definitions(-std=c++14)
+set(CMAKE_CXX_FLAGS "-std=c++14")
+
+if (BUILD_WITH_MARCH_NATIVE)
+  add_compile_options(-march=native)
+else()
+  add_definitions(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
+  set(CMAKE_CXX_FLAGS "-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
+endif()
 
 # pcl 1.7 causes a segfault when it is built with debug mode
 set(CMAKE_BUILD_TYPE "RELEASE")


### PR DESCRIPTION
Related https://github.com/tier4/ndt_omp/pull/8, we changed to not use the architecture-specific SIMD flags in order to support both x64 and aarch64 CPUs.
To accomplish this, we used the `-march=native` option. According to our internal evaluation, this will specify the best option for each CPU architecture.