### PR TITLE
Fix sign of c2 and d1 in computing Hessian of NDT

### DIFF
--- a/include/pclomp/ndt_omp_impl.hpp
+++ b/include/pclomp/ndt_omp_impl.hpp
@@ -354,10 +354,11 @@ pclomp::NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDeri
 		h_ang_b2_ << (cx * cy * cz), (-cx * cy * sz), (cx * sy);
 		h_ang_b3_ << (sx * cy * cz), (-sx * cy * sz), (sx * sy);
 
+		// The sign of 'sx * sz' in c2 is incorrect in [Magnusson 2009], and it is fixed here.
 		h_ang_c2_ << (-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0;
 		h_ang_c3_ << (cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0;
 
-		h_ang_d1_ << (-cy * cz), (cy * sz), (sy);
+		h_ang_d1_ << (-cy * cz), (cy * sz), (-sy);
 		h_ang_d2_ << (-sx * sy * cz), (sx * sy * sz), (sx * cy);
 		h_ang_d3_ << (cx * sy * cz), (-cx * sy * sz), (-cx * cy);
 


### PR DESCRIPTION
Thank you for your great work.

I lately found that the sign of `sx * sz` in c2 and `sy` in d1 in computing Hessian of NDT did not match the result in equation (6.21) of [Magnusson 2009](https://www.researchgate.net/publication/229213868_The_Three-Dimensional_Normal-Distributions_Transform_---_an_Efficient_Representation_for_Registration_Surface_Analysis_and_Loop_Detection) (Page 64)

Based on my calculation, the sign of `sx * sz` in c2 is incorrect in [Magnusson 2009] and it was fixed in [pcl](https://github.com/PointCloudLibrary/pcl) implementation.
However, the sign of `sy` in d1 was an implement mistake and it was fixed 6 month ago by the issue and PR below. 
- PR: https://github.com/PointCloudLibrary/pcl/pull/4889
- Related issue: https://github.com/PointCloudLibrary/pcl/issues/4888

This PR will: 
- Fix the sign of `sy` in d1 
- Add a comment the sign of `sx * sz` in c2 explaining that the formula in the paper/thesis has an incorrect sign, but the formula in the code has the correct sign.