### PR TITLE
Fix call to deprecated function testGradient

### DIFF
--- a/include/pclomp/gicp_omp_impl.hpp
+++ b/include/pclomp/gicp_omp_impl.hpp
@@ -227,7 +227,11 @@ pclomp::GeneralizedIterativeClosestPoint<PointSource, PointTarget>::estimateRigi
     {
       break;
     }
+#if PCL_VERSION_COMPARE(<, 1, 11, 0)
     result = bfgs.testGradient(gradient_tol);
+#else
+    result = bfgs.testGradient();
+#endif
   } while(result == BFGSSpace::Running && inner_iterations_ < max_inner_iterations_);
   if(result == BFGSSpace::NoProgress || result == BFGSSpace::Success || inner_iterations_ == max_inner_iterations_)
   {


### PR DESCRIPTION
* This PR fixes a deprecation warning for PCL >= 1.11.0

### Reason

Starting with PCL version 1.11.0, the function `testGradient(Scalar)` as been deprecated in favor of a new argumentless function `testGradient()`.

Compiling with a recent PCL version thus leads to a deprecation warning, and will break with the use of PCL 1.13:
```
[build] In file included from /path/ndt_omp/include/pclomp/gicp_omp.h:45,
[build]                  from /path/ndt_omp/src/pclomp/gicp_omp.cpp:1:
[build] /usr/include/pcl-1.12/pcl/registration/bfgs.h:164:21: note: declared here
[build]   164 |   BFGSSpace::Status testGradient(Scalar) { return testGradient(); }
[build]       |                     ^~~~~~~~~~~~
...
[build] /path/ndt_omp/include/pclomp/gicp_omp_impl.hpp:231:31: warning: ‘BFGSSpace::Status BFGS<FunctorType>::testGradient(BFGS<FunctorType>::Scalar) [with FunctorType = pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI>::OptimizationFunctorWithIndices; BFGS<FunctorType>::Scalar = double]’ is deprecated: Use `testGradient()` instead (It will be removed in PCL 1.13) [-Wdeprecated-declarations]
```