### PR TITLE
fix: clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -92,10 +92,11 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 0
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-RawStringFormats: 
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
+RawStringFormats:
+  - Language: TextProto
+    Delimiters:
+      - pb
+    BasedOnStyle: google
 ReflowComments:  true
 SortIncludes:    false
 SortUsingDeclarations: false


### PR DESCRIPTION
Signed-off-by: kminoda <koji.minoda@tier4.jp>

Please refer to this issue: https://github.com/koide3/ndt_omp/issues/55

Run `clang-format --dump-config` to verify that the file is correctly modified (it will output error if the config is mal-formatted)