### PR TITLE
Install ROS2 library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,8 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-add_library(ndt_omp
+ament_auto_add_library(ndt_omp
+  SHARED
   src/pclomp/voxel_grid_covariance_omp.cpp
   src/pclomp/ndt_omp.cpp
   src/pclomp/gicp_omp.cpp


### PR DESCRIPTION
This package was using ament_auto_package to build its library, but it was not actually installing the library, so other packages would not be able to find it.  Since this is a fairly simple library, this change just uses the manual ament functions to build and install it.

Signed-off-by: P. J. Reed <phillipreed@hatchbed.com>