### PR TITLE
fix export library target for ROS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,12 +99,14 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-ament_auto_add_library(ndt_omp
+add_library(ndt_omp
   SHARED
   src/pclomp/voxel_grid_covariance_omp.cpp
   src/pclomp/ndt_omp.cpp
   src/pclomp/gicp_omp.cpp
 )
+
+ament_export_targets(ndt_omp HAS_LIBRARY_TARGET)
 
 target_link_libraries(ndt_omp ${PCL_LIBRARIES})
 
@@ -113,6 +115,16 @@ if(OpenMP_CXX_FOUND)
 else()
   message(WARNING "OpenMP not found")
 endif()
+
+install(
+  TARGETS
+    ndt_omp
+  EXPORT ndt_omp
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
 
 ament_auto_package()
 endif()


### PR DESCRIPTION
When we try to use ndt_omp library inside other package in ROS2, we are having issues by using the latest commit. 

```
CMake Error at CMakeLists.txt:40 (add_library):
  Target "my_library" links to target "ndt_omp::ndt_omp" but the
  target was not found.  Perhaps a find_package() call is missing for an
  IMPORTED target, or an ALIAS target is missing?
```

(Of course we've done the find_package(ndt_omp REQUIRED))

We've solved the export of the library in a different way proposed in this pull request. Then, when you want to use the ndt_omp library in other package, we do it in the following way:

```
ament_target_dependencies(my_library ndt_omp)

target_link_libraries(my_library
    ndt_omp::ndt_omp
)
```



