### PR TITLE
build(ndt_omp): add ros_environment dependency (#20)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>ros_environment</buildtool_depend>
 
   <depend condition="$ROS_VERSION == 1">pcl_ros</depend>
   <depend condition="$ROS_VERSION == 1">roscpp</depend>


### PR DESCRIPTION
Needed so that `CMakeLists.txt` can access the `$ROS_VERSION` environment variable in the ROS buildfarm

Ported from https://github.com/tier4/ndt_omp/pull/20