### PR TITLE
Add template instantiation for pcl::PointXYZRGB

### DIFF
--- a/src/pclomp/gicp_omp.cpp
+++ b/src/pclomp/gicp_omp.cpp
@@ -3,4 +3,4 @@
 
 template class pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>;
 template class pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI>;
-
+template class pclomp::GeneralizedIterativeClosestPoint<pcl::PointXYZRGB, pcl::PointXYZRGB>;

--- a/src/pclomp/ndt_omp.cpp
+++ b/src/pclomp/ndt_omp.cpp
@@ -3,3 +3,4 @@
 
 template class pclomp::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ>;
 template class pclomp::NormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI>;
+template class pclomp::NormalDistributionsTransform<pcl::PointXYZRGB, pcl::PointXYZRGB>;

--- a/src/pclomp/voxel_grid_covariance_omp.cpp
+++ b/src/pclomp/voxel_grid_covariance_omp.cpp
@@ -3,3 +3,4 @@
 
 template class pclomp::VoxelGridCovariance<pcl::PointXYZ>;
 template class pclomp::VoxelGridCovariance<pcl::PointXYZI>;
+template class pclomp::VoxelGridCovariance<pcl::PointXYZRGB>;


### PR DESCRIPTION
Hello @koide3, 

In this PR, I have incorporate template instantiation pcl::PointXYZRGB so that the ndt library support pointcloud which are colored as well. I have tested it and it works correctly. You can merge this PR if this makes sense to you. 

Thanks.  