### PR TITLE
Don't add SSE flags if arm64 processor is detected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
   
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "i386|i686")
     message(STATUS "x86 architecture detected, adding SSE4.2 flags")
-    add_compile_options(-msse4.2)
+    add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
   elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
     message(STATUS "ARM64 architecture detected, skipping SSE4.2 flags")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,17 @@ add_definitions(-std=c++14)
 set(CMAKE_CXX_FLAGS "-std=c++14")
 
 if (BUILD_WITH_MARCH_NATIVE)
+  message(STATUS "Compiling with -march=native")
   add_compile_options(-march=native)
 else()
-  add_definitions(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
-  set(CMAKE_CXX_FLAGS "-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2")
+  message(STATUS "Compiling with architecture-specific SIMD flags for portability")
+  
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "i386|i686")
+    message(STATUS "x86 architecture detected, adding SSE4.2 flags")
+    add_compile_options(-msse4.2)
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
+    message(STATUS "ARM64 architecture detected, skipping SSE4.2 flags")
+  endif()
 endif()
 
 # pcl 1.7 causes a segfault when it is built with debug mode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
   message(STATUS "Compiling with architecture-specific SIMD flags for portability")
   
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "i386|i686")
-    message(STATUS "x86 architecture detected, adding SSE4.2 flags")
+    message(STATUS "x86 architecture detected, adding SSE flags")
     add_compile_options(-msse -msse2 -msse3 -msse4 -msse4.1 -msse4.2)
   elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
     message(STATUS "ARM64 architecture detected, skipping SSE4.2 flags")


### PR DESCRIPTION
I started providing Docker containers for [Multi-Robot-Graph-SLAM](https://github.com/aserbremen/Multi-Robot-Graph-SLAM) for arm64 architecture. The SLAM provides registration with ndt_omp, fast_gicp, and small_gicp. For this I added compiler flags depending on detected system processor. 

This pull requests checks whether x86 system processor is detected and only then adds the compile definitions for SSE, for arm64 architectures it skips them. 